### PR TITLE
chore: release v0.1.1 — absolute-import fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "molecule-ai-workspace-runtime"
-version = "0.1.0"
+version = "0.1.1"
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Releases #2 (absolute-import fix) to PyPI. Templates pinned at `>=0.1.0` will pick up 0.1.1 on next image rebuild — no template-side PRs needed.

After merge, push tag `v0.1.1` to trigger publish.yml.