### PR TITLE
chore: gitignore credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,19 @@ build/
 .venv/
 venv/
 *.pyc
+
+# Credentials — added by chore/credentials-gitignore batch
+.env
+.env.local
+.env.*.local
+.env.*
+!.env.example
+!.env.sample
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+.secrets/
+.auth-token
+.auth_token


### PR DESCRIPTION
Standard credential gitignore added: .env / .env.local / .env.*, *.pem/*.key/*.crt/*.p12/*.pfx, .secrets/, .auth-token / .auth_token. Part of org-wide rollout per CEO directive 2026-04-16.



🤖 Generated with [Claude Code](https://claude.com/claude-code)