### PR TITLE
fix: gate session resume on file existence (closes #488 in molecule-core)

### DIFF
--- a/molecule_runtime/claude_sdk_executor.py
+++ b/molecule_runtime/claude_sdk_executor.py
@@ -26,6 +26,7 @@ one active stream at any given moment).
 from __future__ import annotations
 
 import asyncio
+import glob
 import logging
 import os
 import sys
@@ -39,7 +40,7 @@ from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.utils import new_agent_text_message
 
-from executor_helpers import (
+from molecule_runtime.executor_helpers import (
     CONFIG_MOUNT,
     MEMORY_CONTENT_MAX_CHARS,
     WORKSPACE_MOUNT,
@@ -233,6 +234,49 @@ class ClaudeSDKExecutor(AgentExecutor):
             return prompt
         return f"[Prior context from memory]\n{memories}\n\n{prompt}"
 
+    # Session-file lookup paths used by _resolve_resume(). claude-code stores
+    # sessions at /root/.claude/projects/<cwd-with-slashes-as-dashes>/<id>.jsonl.
+    # We probe a handful of well-known locations; if no match, the session is
+    # gone (volume recycled, prior container destroyed) and resuming would
+    # crash the CLI immediately. See #488.
+    _SESSION_FILE_PATTERNS = (
+        "/root/.claude/projects/*/{id}.jsonl",
+        "/root/.claude/sessions/{id}.jsonl",
+        "/home/agent/.claude/projects/*/{id}.jsonl",
+        "/home/agent/.claude/sessions/{id}.jsonl",
+    )
+
+    def _resolve_resume(self) -> str | None:
+        """Return self._session_id ONLY if its session file actually exists.
+
+        Fixes #488 (session-stale loop). When a workspace container is
+        recreated or the claude-sessions volume is recycled, the in-memory
+        session_id from a prior instance references a file that no longer
+        exists. Passing it as resume=<id> to the SDK causes the CLI to
+        crash with "No conversation found with session ID" on every call,
+        forever — the existing #75 reset only fires AFTER the first
+        ProcessError lands, and per-cycle executor re-instantiation can
+        reload the stale id from elsewhere.
+
+        Gating resume on real-file existence breaks the loop at the
+        source: if the file is gone, drop both the in-memory id AND the
+        resume arg, so the CLI starts a fresh session on this turn.
+        Logged at INFO when a stale id is dropped so operators can
+        correlate with the cron schedule that triggered the reset.
+        """
+        sid = self._session_id
+        if not sid:
+            return None
+        for pattern in self._SESSION_FILE_PATTERNS:
+            if glob.glob(pattern.format(id=sid)):
+                return sid
+        logger.info(
+            "SDK session file missing for %s — dropping resume, fresh session (#488)",
+            sid,
+        )
+        self._session_id = None
+        return None
+
     def _build_options(self) -> Any:
         """Build ClaudeAgentOptions.
 
@@ -243,6 +287,9 @@ class ClaudeSDKExecutor(AgentExecutor):
 
         The MCP server launcher uses `sys.executable` so tests and alternate
         virtual-env layouts don't depend on a `python3` shim being on PATH.
+
+        Resume is gated through _resolve_resume() so a stale session id
+        from a previous container never crashes the CLI — see #488.
         """
         mcp_servers = {
             "a2a": {
@@ -256,7 +303,7 @@ class ClaudeSDKExecutor(AgentExecutor):
             cwd=self._resolve_cwd(),
             mcp_servers=mcp_servers,
             system_prompt=self._build_system_prompt(),
-            resume=self._session_id,
+            resume=self._resolve_resume(),
         )
 
     # ------------------------------------------------------------------

--- a/molecule_runtime/cli_executor.py
+++ b/molecule_runtime/cli_executor.py
@@ -36,8 +36,8 @@ from a2a.server.agent_execution import AgentExecutor, RequestContext
 from a2a.server.events import EventQueue
 from a2a.utils import new_agent_text_message
 
-from config import RuntimeConfig
-from executor_helpers import (
+from molecule_runtime.config import RuntimeConfig
+from molecule_runtime.executor_helpers import (
     CONFIG_MOUNT,
     MEMORY_CONTENT_MAX_CHARS,
     WORKSPACE_MOUNT,

--- a/molecule_runtime/main.py
+++ b/molecule_runtime/main.py
@@ -25,9 +25,9 @@ from a2a.server.tasks import InMemoryTaskStore
 from a2a.types import AgentCard, AgentCapabilities, AgentSkill
 
 from molecule_runtime.adapters import get_adapter, AdapterConfig
-from config import load_config
-from heartbeat import HeartbeatLoop
-from preflight import run_preflight, render_preflight_report
+from molecule_runtime.config import load_config
+from molecule_runtime.heartbeat import HeartbeatLoop
+from molecule_runtime.preflight import run_preflight, render_preflight_report
 from builtin_tools.awareness_client import get_awareness_config
 import uuid as _uuid
 

--- a/molecule_runtime/preflight.py
+++ b/molecule_runtime/preflight.py
@@ -4,7 +4,7 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from config import WorkspaceConfig
+from molecule_runtime.config import WorkspaceConfig
 
 SUPPORTED_RUNTIMES = {
     "langgraph",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "molecule-ai-workspace-runtime"
-version = "0.1.1"
+version = "0.1.2"
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"
 license = {text = "BSL-1.1"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+"""Test-env stubs for workspace-container deps.
+
+`claude_agent_sdk` and `a2a` are installed inside the claude-code workspace
+image, not in this package's test environment. Rather than pulling them as
+dev deps (they're heavy + change frequently), we stub them before any test
+module imports `molecule_runtime.*` — the stubs just need to be importable
+so the package source doesn't crash at collect time.
+
+Every known submodule + symbol used anywhere in `molecule_runtime/` is
+stubbed here, so test_imports.py (walking every module) + test_session_
+resume_gate.py (ClaudeSDKExecutor methods) + future tests all share one
+consistent stub set.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+
+def _ensure_package(dotted: str) -> types.ModuleType:
+    """Create a package-shaped module at `dotted` and all its parents.
+
+    Key detail: the __path__ attribute makes Python treat the stub as a
+    PACKAGE, so `from parent.child import X` resolves correctly. Without
+    __path__ you get `'parent' is not a package` which is the exact bug
+    that broke our first-attempt stubs.
+    """
+    parts = dotted.split(".")
+    for i in range(1, len(parts) + 1):
+        name = ".".join(parts[:i])
+        if name not in sys.modules:
+            mod = types.ModuleType(name)
+            mod.__path__ = []  # type: ignore[attr-defined]
+            sys.modules[name] = mod
+        if i > 1:
+            parent = sys.modules[".".join(parts[:i-1])]
+            child_name = parts[i-1]
+            if not hasattr(parent, child_name):
+                setattr(parent, child_name, sys.modules[name])
+    return sys.modules[dotted]
+
+
+def _set_attrs(mod: types.ModuleType, attrs: list[str]) -> None:
+    """Attach placeholder classes/functions. AgentExecutor is a class
+    so subclasses can inherit; everything else is a no-op callable."""
+    for attr in attrs:
+        if hasattr(mod, attr):
+            continue
+        if attr in ("AgentExecutor",):
+            setattr(mod, attr, type(attr, (), {}))
+        else:
+            setattr(mod, attr, lambda *a, **kw: None)
+
+
+# claude_agent_sdk — used by claude_sdk_executor.py
+if "claude_agent_sdk" not in sys.modules:
+    sdk_stub = types.ModuleType("claude_agent_sdk")
+    sdk_stub.ClaudeAgentOptions = lambda **kwargs: types.SimpleNamespace(**kwargs)
+    sdk_stub.query = lambda **kwargs: iter([])
+    sys.modules["claude_agent_sdk"] = sdk_stub
+
+# a2a + submodules — every import path in the package gets stubbed.
+_A2A_MODULES: dict[str, list[str]] = {
+    "a2a": [],
+    "a2a.server": [],
+    "a2a.server.agent_execution": ["AgentExecutor", "RequestContext"],
+    "a2a.server.events": ["EventQueue"],
+    "a2a.server.tasks": ["TaskUpdater", "InMemoryTaskStore"],
+    "a2a.server.apps": ["A2AStarletteApplication"],
+    "a2a.server.request_handlers": ["DefaultRequestHandler"],
+    "a2a.types": [
+        "Part", "TextPart", "AgentCard", "AgentCapabilities", "AgentSkill",
+        "TaskStatus", "TaskState", "TaskStatusUpdateEvent",
+    ],
+    "a2a.utils": ["new_agent_text_message"],
+}
+for dotted, attrs in _A2A_MODULES.items():
+    mod = _ensure_package(dotted)
+    _set_attrs(mod, attrs)

--- a/tests/test_session_resume_gate.py
+++ b/tests/test_session_resume_gate.py
@@ -1,0 +1,107 @@
+"""Tests for #488 — session-file existence gate on _resolve_resume().
+
+The bug: claude-code stores sessions at /root/.claude/projects/<hash>/<id>.jsonl.
+When a workspace container is recreated, the in-memory session_id from a prior
+instance references a file that's gone — passing it as resume=<id> crashes the
+CLI with "No conversation found with session ID" on every call.
+
+The fix (in HermesA2AExecutor — wait, claude_sdk_executor): _resolve_resume()
+gates self._session_id on glob-matching the session file in any of the known
+locations. If no match, drop the id (set self._session_id = None) AND return
+None so the SDK starts a fresh session.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from molecule_runtime.claude_sdk_executor import ClaudeSDKExecutor
+
+
+@pytest.fixture
+def executor():
+    """Build an executor with the minimum to exercise _resolve_resume()."""
+    e = ClaudeSDKExecutor.__new__(ClaudeSDKExecutor)
+    e._session_id = None
+    return e
+
+
+def test_resolve_resume_returns_none_when_no_session_id(executor):
+    """Baseline: no session set → no resume, no glob calls (cheap path)."""
+    executor._session_id = None
+    with patch("molecule_runtime.claude_sdk_executor.glob.glob") as mock_glob:
+        result = executor._resolve_resume()
+    assert result is None
+    mock_glob.assert_not_called()
+
+
+def test_resolve_resume_keeps_id_when_session_file_exists(executor):
+    """Session id matches a real file → keep the id, return it for resume."""
+    sid = "abcd1234-fake-session-id"
+    executor._session_id = sid
+    with patch("molecule_runtime.claude_sdk_executor.glob.glob") as mock_glob:
+        # First pattern matches; later patterns shouldn't be probed (short-circuit).
+        mock_glob.side_effect = [[f"/root/.claude/projects/-app/{sid}.jsonl"], [], [], []]
+        result = executor._resolve_resume()
+    assert result == sid
+    assert executor._session_id == sid  # not cleared
+    # Only one glob call needed (early-exit on first match)
+    assert mock_glob.call_count == 1
+
+
+def test_resolve_resume_drops_id_when_session_file_missing(executor):
+    """Stale session id (file gone) → drop in-memory + return None."""
+    sid = "stale-session-from-prior-container"
+    executor._session_id = sid
+    with patch("molecule_runtime.claude_sdk_executor.glob.glob", return_value=[]):
+        result = executor._resolve_resume()
+    assert result is None
+    assert executor._session_id is None  # cleared
+
+
+def test_resolve_resume_probes_all_patterns_until_match(executor):
+    """Late-pattern match is still found — agent-uid layout works alongside root."""
+    sid = "found-only-in-agent-home"
+    executor._session_id = sid
+    call_log = []
+
+    def fake_glob(pattern):
+        call_log.append(pattern)
+        # Match only the third pattern (/home/agent/.claude/projects/*/...)
+        if pattern.startswith("/home/agent/.claude/projects"):
+            return [f"/home/agent/.claude/projects/-app/{sid}.jsonl"]
+        return []
+
+    with patch("molecule_runtime.claude_sdk_executor.glob.glob", side_effect=fake_glob):
+        result = executor._resolve_resume()
+
+    assert result == sid
+    assert executor._session_id == sid
+    # First two patterns probed and missed, then third hit
+    assert len(call_log) == 3
+
+
+def test_resolve_resume_log_message_includes_session_id(executor, caplog):
+    """When dropping a stale id, log message includes the id for operator triage."""
+    import logging
+    sid = "specific-id-for-log-check"
+    executor._session_id = sid
+    with patch("molecule_runtime.claude_sdk_executor.glob.glob", return_value=[]):
+        with caplog.at_level(logging.INFO, logger="molecule_runtime.claude_sdk_executor"):
+            executor._resolve_resume()
+    # At least one log record mentions the dropped session id
+    assert any(sid in r.message for r in caplog.records), \
+        f"expected log message mentioning {sid}, got: {[r.message for r in caplog.records]}"
+
+
+def test_resolve_resume_log_references_488(executor, caplog):
+    """Log line references #488 so future debuggers find the issue history."""
+    import logging
+    executor._session_id = "any-stale-id"
+    with patch("molecule_runtime.claude_sdk_executor.glob.glob", return_value=[]):
+        with caplog.at_level(logging.INFO, logger="molecule_runtime.claude_sdk_executor"):
+            executor._resolve_resume()
+    assert any("#488" in r.message for r in caplog.records)

--- a/tests/test_session_resume_gate.py
+++ b/tests/test_session_resume_gate.py
@@ -14,9 +14,41 @@ None so the SDK starts a fresh session.
 from __future__ import annotations
 
 import os
+import sys
+import types
 from unittest.mock import patch
 
 import pytest
+
+# Stub claude_agent_sdk before importing the executor — the real SDK isn't a
+# runtime dep of this package (it's installed inside the claude-code workspace
+# image, not in the CI env). We only need the module to be importable; the
+# tests here don't exercise the SDK, only _resolve_resume().
+if "claude_agent_sdk" not in sys.modules:
+    _stub = types.ModuleType("claude_agent_sdk")
+    _stub.ClaudeAgentOptions = lambda **kwargs: types.SimpleNamespace(**kwargs)
+    sys.modules["claude_agent_sdk"] = _stub
+
+# Same for a2a, which is a workspace-image dep but not a test-env dep.
+for mod_path, attr in [
+    ("a2a", None),
+    ("a2a.server", None),
+    ("a2a.server.agent_execution", "AgentExecutor"),
+    ("a2a.server.agent_execution", "RequestContext"),
+    ("a2a.server.events", "EventQueue"),
+    ("a2a.utils", "new_agent_text_message"),
+]:
+    if mod_path not in sys.modules:
+        m = types.ModuleType(mod_path)
+        sys.modules[mod_path] = m
+    if attr:
+        mod = sys.modules[mod_path]
+        if not hasattr(mod, attr):
+            # Use a minimal base class for AgentExecutor so inheritance works.
+            if attr == "AgentExecutor":
+                setattr(mod, attr, type("AgentExecutor", (), {}))
+            else:
+                setattr(mod, attr, lambda *a, **kw: None)
 
 from molecule_runtime.claude_sdk_executor import ClaudeSDKExecutor
 

--- a/tests/test_session_resume_gate.py
+++ b/tests/test_session_resume_gate.py
@@ -14,42 +14,12 @@ None so the SDK starts a fresh session.
 from __future__ import annotations
 
 import os
-import sys
-import types
 from unittest.mock import patch
 
 import pytest
 
-# Stub claude_agent_sdk before importing the executor — the real SDK isn't a
-# runtime dep of this package (it's installed inside the claude-code workspace
-# image, not in the CI env). We only need the module to be importable; the
-# tests here don't exercise the SDK, only _resolve_resume().
-if "claude_agent_sdk" not in sys.modules:
-    _stub = types.ModuleType("claude_agent_sdk")
-    _stub.ClaudeAgentOptions = lambda **kwargs: types.SimpleNamespace(**kwargs)
-    sys.modules["claude_agent_sdk"] = _stub
-
-# Same for a2a, which is a workspace-image dep but not a test-env dep.
-for mod_path, attr in [
-    ("a2a", None),
-    ("a2a.server", None),
-    ("a2a.server.agent_execution", "AgentExecutor"),
-    ("a2a.server.agent_execution", "RequestContext"),
-    ("a2a.server.events", "EventQueue"),
-    ("a2a.utils", "new_agent_text_message"),
-]:
-    if mod_path not in sys.modules:
-        m = types.ModuleType(mod_path)
-        sys.modules[mod_path] = m
-    if attr:
-        mod = sys.modules[mod_path]
-        if not hasattr(mod, attr):
-            # Use a minimal base class for AgentExecutor so inheritance works.
-            if attr == "AgentExecutor":
-                setattr(mod, attr, type("AgentExecutor", (), {}))
-            else:
-                setattr(mod, attr, lambda *a, **kw: None)
-
+# claude_agent_sdk + a2a stubs live in tests/conftest.py so every test
+# module shares one consistent stub set (see the conftest for why).
 from molecule_runtime.claude_sdk_executor import ClaudeSDKExecutor
 
 


### PR DESCRIPTION
Closes Molecule-AI/molecule-core#488. Cycle 6+ of this defect — directly shipping per CEO directive 2026-04-16 "for critical issues, you can fix directly right now without informing me".

## Why
Workspaces appeared online but every cron tick failed silently with `No conversation found with session ID`. Backend Engineer received 5 idle pulses in a row without claiming a single open Hermes issue because the bug breaks the agent's tool-call execution before `gh issue list` can fire — i.e. the team can't unblock themselves on the bug that breaks their unblocking.

## Fix
`_resolve_resume()` gates `self._session_id` on glob-matching the actual session file in `/root/.claude/projects/*/<id>.jsonl` (and 3 other known locations). If gone, drops the id and returns None so the SDK starts fresh. Logged at INFO with #488 reference.

## Drive-by
4 files had stale `from X import` (config / heartbeat / preflight / executor_helpers) — same regression class as #1. Rewrote to absolute `from molecule_runtime.X` so imports resolve in test environments too.

## Tests
6 new tests pass locally. Plus the 10 existing import-grep tests still pass.

## Release plan
- Merge → push v0.1.2 tag → publish.yml auto-publishes to PyPI
- Then I'll rebuild workspace-template:claude-code locally to pick up 0.1.2
- Mass-restart workspaces once to clear DB-side stale state

🤖 Generated with [Claude Code](https://claude.com/claude-code)