### PR TITLE
fix: pin a2a-sdk<1.0 — keep a2a.server.apps import working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "molecule-ai-workspace-runtime"
-version = "0.1.2"
+version = "0.1.3"
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"
 license = {text = "BSL-1.1"}
 readme = "README.md"
 # Don't pin heavy deps — each adapter adds its own
 dependencies = [
-    "a2a-sdk[http-server]>=0.3.25",
+    # Upper bound: a2a-sdk 1.0.0 dropped the a2a.server.apps module we import
+    # in main.py. Keep on the 0.3.x line until we migrate to the 1.x API.
+    "a2a-sdk[http-server]>=0.3.25,<1.0",
     "httpx>=0.27.0",
     "uvicorn>=0.30.0",
     "starlette>=0.38.0",


### PR DESCRIPTION
## Summary

a2a-sdk 1.0.0 restructured the package and removed a2a.server.apps, which main.py imports for A2AStarletteApplication. Current loose constraint (>=0.3.25) resolves to 1.0.0 on fresh installs → runtime crashes at startup with ModuleNotFoundError → consumers (molecule-controlplane EC2 provisioner) saw workspaces stuck in 'provisioning' forever.

Bump to 0.1.3 and pin <1.0.

Companion: molecule-controlplane PR #174 adds the same pin at pip-install time. That unblocks users now; this PR fixes the upstream package so other downstream installers don't re-hit the trap.

## Test plan

- [ ] Merge + tag v0.1.3 → publish workflow pushes to PyPI
- [ ] Provision a fresh workspace EC2 via CP → runtime imports successfully → workspace reaches 'online'