### PR TITLE
fix(adapter-loader): fall back to any BaseAdapter subclass

### DIFF
--- a/molecule_runtime/adapters/__init__.py
+++ b/molecule_runtime/adapters/__init__.py
@@ -53,13 +53,33 @@ def get_adapter(runtime: str) -> type[BaseAdapter]:
     if adapter_module:
         try:
             mod = importlib.import_module(adapter_module)
-            cls = getattr(mod, "Adapter")
-            if cls and issubclass(cls, BaseAdapter):
-                return cls
         except Exception as e:
             raise KeyError(
-                f"ADAPTER_MODULE={adapter_module!r} could not be loaded: {e}"
+                f"ADAPTER_MODULE={adapter_module!r} could not be imported: {e}"
             ) from e
+
+        # Resolution order inside the imported module:
+        # 1. An explicit `Adapter = XxxAdapter` alias (most ergonomic).
+        # 2. Any attribute that is a BaseAdapter subclass — unblocks
+        #    standalone adapter repos whose author forgot to add the alias
+        #    (e.g. claude-code, langgraph, openclaw templates pre-2026-04-20).
+        #    Without this fallback, a perfectly valid ClaudeCodeAdapter
+        #    class in the module can't be loaded and provisioning fails at
+        #    runtime with "module 'adapter' has no attribute 'Adapter'".
+        cls = getattr(mod, "Adapter", None)
+        if cls is None:
+            for name in dir(mod):
+                if name.startswith("_"):
+                    continue
+                obj = getattr(mod, name, None)
+                if isinstance(obj, type) and obj is not BaseAdapter and issubclass(obj, BaseAdapter):
+                    cls = obj
+                    break
+        if cls is not None and issubclass(cls, BaseAdapter):
+            return cls
+        raise KeyError(
+            f"ADAPTER_MODULE={adapter_module!r} imported but no BaseAdapter subclass found"
+        )
 
     # Fall back to built-in discovery (for local dev / monorepo)
     adapters = discover_adapters()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "molecule-ai-workspace-runtime"
-version = "0.1.3"
+version = "0.1.4"
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"
 license = {text = "BSL-1.1"}

--- a/tests/test_adapter_loader.py
+++ b/tests/test_adapter_loader.py
@@ -1,0 +1,108 @@
+"""Tests for get_adapter() ADAPTER_MODULE resolution.
+
+The claude-code, langgraph, and openclaw template adapters in prod on
+2026-04-20 did NOT add the `Adapter = XxxAdapter` alias that the loader
+originally required. The runtime now falls back to scanning the module
+for any BaseAdapter subclass when the alias is missing. These tests pin
+that behaviour so a future "cleanup" doesn't re-introduce the footgun.
+"""
+
+import sys
+import types
+import pytest
+
+from molecule_runtime.adapters import get_adapter
+from molecule_runtime.adapters.base import BaseAdapter
+
+
+class _FakeAdapterCC(BaseAdapter):
+    """Shaped like the real ClaudeCodeAdapter (class name != 'Adapter')."""
+
+    @staticmethod
+    def name() -> str:
+        return "claude-code"
+
+    @staticmethod
+    def display_name() -> str:
+        return "Claude Code"
+
+    @staticmethod
+    def description() -> str:
+        return "Test adapter"
+
+    @staticmethod
+    def get_config_schema() -> dict:
+        return {}
+
+    async def setup(self, config):
+        return None
+
+    async def build_agent_executor(self, config):
+        return None
+
+
+def _install_module(monkeypatch, name, **attrs):
+    """Stage a fake module in sys.modules so importlib.import_module finds it."""
+    mod = types.ModuleType(name)
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    monkeypatch.setitem(sys.modules, name, mod)
+
+
+def test_loader_picks_up_explicit_alias(monkeypatch):
+    _install_module(monkeypatch, "adapter_with_alias", Adapter=_FakeAdapterCC)
+    monkeypatch.setenv("ADAPTER_MODULE", "adapter_with_alias")
+    cls = get_adapter("claude-code")
+    assert cls is _FakeAdapterCC
+
+
+def test_loader_falls_back_to_any_baseadapter_subclass(monkeypatch):
+    # Only the canonical-name export is missing. The ClaudeCodeAdapter
+    # class alone should still resolve — that's the whole bug fix.
+    _install_module(
+        monkeypatch, "adapter_without_alias", ClaudeCodeAdapter=_FakeAdapterCC
+    )
+    monkeypatch.setenv("ADAPTER_MODULE", "adapter_without_alias")
+    cls = get_adapter("claude-code")
+    assert cls is _FakeAdapterCC
+
+
+def test_loader_ignores_non_adapter_attrs(monkeypatch):
+    # Module has noise (constants, functions, unrelated classes); the
+    # loader must skip past them and still find the real adapter.
+    class NotAnAdapter:  # intentionally NOT a BaseAdapter
+        pass
+
+    _install_module(
+        monkeypatch,
+        "adapter_with_noise",
+        SOME_CONST=42,
+        helper=lambda: None,
+        Junk=NotAnAdapter,
+        MyClaudeAdapter=_FakeAdapterCC,
+    )
+    monkeypatch.setenv("ADAPTER_MODULE", "adapter_with_noise")
+    cls = get_adapter("claude-code")
+    assert cls is _FakeAdapterCC
+
+
+def test_loader_errors_when_module_has_no_subclass(monkeypatch):
+    _install_module(monkeypatch, "adapter_empty", SOMETHING=42)
+    monkeypatch.setenv("ADAPTER_MODULE", "adapter_empty")
+    with pytest.raises(KeyError, match="no BaseAdapter subclass"):
+        get_adapter("claude-code")
+
+
+def test_loader_errors_when_module_missing(monkeypatch):
+    monkeypatch.setenv("ADAPTER_MODULE", "definitely_not_installed_xyz")
+    with pytest.raises(KeyError, match="could not be imported"):
+        get_adapter("claude-code")
+
+
+def test_loader_does_not_return_baseadapter_itself(monkeypatch):
+    # Don't accidentally return BaseAdapter when it's re-exported by the
+    # module — regression guard for the fallback scan.
+    _install_module(monkeypatch, "adapter_reexports_base", BaseAdapter=BaseAdapter)
+    monkeypatch.setenv("ADAPTER_MODULE", "adapter_reexports_base")
+    with pytest.raises(KeyError, match="no BaseAdapter subclass"):
+        get_adapter("claude-code")


### PR DESCRIPTION
## Symptom

Workspaces stuck in provisioning even after the a2a-sdk<1.0 fix. Console output from prod (workspace a9d7ccee):

\`\`\`
RUNTIME CRASHED — log:
File \"/opt/molecule-venv/lib/python3.12/site-packages/molecule_runtime/adapters/__init__.py\", line 56, in get_adapter
    cls = getattr(mod, \"Adapter\")
AttributeError: module 'adapter' has no attribute 'Adapter'
\`\`\`

## Root cause

\`get_adapter()\` required the module named by \`ADAPTER_MODULE\` to export a class literally called \`Adapter\`. Only the Hermes adapter template has \`Adapter = HermesAdapter\`. The claude-code, langgraph, and openclaw templates all export \`ClaudeCodeAdapter\` / \`LangGraphAdapter\` / \`OpenClawAdapter\` directly — so their workspaces fail at runtime startup despite being valid BaseAdapter subclasses.

## Fix

When the literal \`Adapter\` attr is absent, scan the module for any attribute that is a proper BaseAdapter subclass (excluding BaseAdapter itself — tested). Explicit alias still wins when present.

## Ship

- Bump to 0.1.4
- After merge: push \`v0.1.4\` tag → PyPI publish workflow triggers → new workspace provisions pick it up automatically

## Tests (6 new)

- alias wins
- subclass fallback works
- module noise (constants / non-adapter classes) is skipped
- empty module → KeyError
- missing module → KeyError
- BaseAdapter re-export not selected (regression guard)

All 6 pass. Pre-existing \`test_plugins_builtins_env_scrub\` failure is unrelated and present on main.