### PR TITLE
chore: bump to 0.1.5 for X-Molecule-Org-Id header fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "molecule-ai-workspace-runtime"
-version = "0.1.4"
+version = "0.1.5"
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"
 license = {text = "BSL-1.1"}


### PR DESCRIPTION
Companion to #35. The v0.1.5 tag was already pushed but the release workflow failed because pyproject.toml still said 0.1.4 (PyPI rejected duplicate). Merge this → delete + re-push v0.1.5 tag.