### PR TITLE
feat: pre-commit hook to block internal paths in public monorepo (A)

### DIFF
--- a/molecule_runtime/main.py
+++ b/molecule_runtime/main.py
@@ -84,6 +84,15 @@ async def main():  # pragma: no cover
     from molecule_runtime.credential_helper import install_credential_helper
     install_credential_helper()
 
+    # 0.2 Pre-commit hook installer — refuse commits that add internal-flavored
+    # paths to the public monorepo. Runs at the agent's local git, so leaks
+    # get instant feedback with the redirect command in the same response
+    # cycle the agent ran `git commit` in. Hook is a no-op in non-public
+    # repos (internal, plugins, templates, third-party). See precommit_hook.py
+    # for the full rationale.
+    from molecule_runtime.precommit_hook import install_pre_commit_hook
+    install_pre_commit_hook()
+
     # 0.5 Initialise OpenTelemetry (no-op if packages not installed)
     setup_telemetry(service_name=workspace_id)
 

--- a/molecule_runtime/precommit_hook.py
+++ b/molecule_runtime/precommit_hook.py
@@ -1,0 +1,121 @@
+"""Pre-commit hook installer — block internal-flavored paths in public monorepo.
+
+Companion to ``credential_helper`` (#1933). Lifts the per-template wiring
+that would otherwise need to live in each Dockerfile + entrypoint.sh:
+copy the hook script to a known location, set ``core.hooksPath`` so git
+finds it, and now every ``git commit`` inside the public monorepo gets a
+local refusal with the redirect command in the same error.
+
+Why a local hook is the right layer
+===================================
+
+Agents try to ``git add /research/foo.md`` despite SHARED_RULES, the
+``.gitignore`` patterns, and the CI gate. Each leak attempt costs ~5
+cycles: PR opens, CI fails (now that ``Block forbidden paths`` is
+required), agent retries with workaround. Pollutes git history with
+reverts.
+
+A pre-commit hook converts the failure from "PR opens then fails 5
+minutes later" to "commit refused immediately, with the recovery
+command printed in the same response cycle the agent ran ``git commit``
+in." Agents act on what's in the current response context — putting the
+redirect command literally in the error message they see is the highest
+density of feedback we can provide.
+
+Scoped to public monorepo only
+==============================
+
+The hook checks ``git remote get-url origin`` and only enforces when the
+repo is ``Molecule-AI/molecule-monorepo`` or ``Molecule-AI/molecule-core``.
+Inside ``Molecule-AI/internal`` (where ``research/``, ``marketing/``
+etc. legitimately belong) the hook is a no-op. Same for plugin /
+template / third-party repos.
+
+Idempotence + non-clobber
+=========================
+
+If git's ``core.hooksPath`` is already set to something else (operator
+configured a custom hook chain), we don't overwrite — we log a warning
+and skip. The hook script itself is rewritten on every startup so
+runtime upgrades pick up the latest pattern list without manual action.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import stat
+import subprocess
+from importlib import resources
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_HOOKS_DIR = Path(os.environ.get("HOME", "/home/agent")) / ".molecule-runtime" / "git-hooks"
+_HOOK_SCRIPT_NAME = "pre-commit"
+_BUNDLED_SCRIPT = "pre-commit-block-internal-paths.sh"
+
+
+def _existing_hooks_path() -> str | None:
+    """Read git's current global core.hooksPath, or None if unset."""
+    try:
+        result = subprocess.run(
+            ["git", "config", "--global", "--get", "core.hooksPath"],
+            check=False, capture_output=True, text=True,
+        )
+        # Exit 1 with empty stdout means "not set" — that's the case we want
+        # to fill in. Any other non-empty value means an existing chain we
+        # shouldn't clobber.
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+        return None
+    except FileNotFoundError:
+        # No git binary — install_pre_commit_hook will skip everything anyway.
+        return None
+
+
+def _extract_hook(target: Path) -> None:
+    """Copy bundled hook script to the per-user hooks dir + chmod +x."""
+    pkg_scripts = resources.files("molecule_runtime").joinpath("scripts")
+    src_bytes = pkg_scripts.joinpath(_BUNDLED_SCRIPT).read_bytes()
+    if target.exists() and target.read_bytes() == src_bytes:
+        return  # idempotent — no change
+    target.write_bytes(src_bytes)
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def install_pre_commit_hook() -> None:
+    """Install + activate the block-internal-paths pre-commit hook.
+
+    Safe to call multiple times. Only sets ``core.hooksPath`` if it was
+    previously unset — never clobbers an operator-configured chain.
+    """
+    if not shutil.which("git"):
+        log.info("precommit_hook: no git binary on PATH — skip installation")
+        return
+
+    try:
+        _HOOKS_DIR.mkdir(parents=True, exist_ok=True)
+        _extract_hook(_HOOKS_DIR / _HOOK_SCRIPT_NAME)
+    except (OSError, ModuleNotFoundError) as exc:
+        log.warning("precommit_hook: cannot extract hook (%s) — skip", exc)
+        return
+
+    existing = _existing_hooks_path()
+    if existing and Path(existing).resolve() != _HOOKS_DIR.resolve():
+        log.warning(
+            "precommit_hook: git core.hooksPath already set to %s — leaving it alone. "
+            "Internal-paths gate will NOT fire on commits in the public monorepo. "
+            "If this is intentional, point that hooks dir at %s/%s as well.",
+            existing, _HOOKS_DIR, _HOOK_SCRIPT_NAME,
+        )
+        return
+
+    try:
+        subprocess.run(
+            ["git", "config", "--global", "core.hooksPath", str(_HOOKS_DIR)],
+            check=True, capture_output=True,
+        )
+        log.info("precommit_hook: installed and activated at %s", _HOOKS_DIR / _HOOK_SCRIPT_NAME)
+    except subprocess.SubprocessError as exc:
+        log.warning("precommit_hook: git config failed (%s) — hook installed but inactive", exc)

--- a/molecule_runtime/scripts/pre-commit-block-internal-paths.sh
+++ b/molecule_runtime/scripts/pre-commit-block-internal-paths.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# pre-commit hook — refuse commits that add internal-flavored paths to the
+# public monorepo. Only enforces in the Molecule-AI public repos; no-op in
+# every other repo (including the canonical internal one) so agents can
+# still write `research/foo.md` inside `Molecule-AI/internal`.
+#
+# Why this hook exists
+# ====================
+#
+# Despite SHARED_RULES.md, .gitignore, and a CI gate, agents still try to
+# `git add /research/...` from their cwd in `molecule-monorepo`. Each leak
+# attempt costs ~5 cycles (PR opens, CI fails, agent retries with
+# workaround) and pollutes git history with reverts. This hook converts
+# the failure mode from "PR fails" → "commit refused at the agent's local
+# git" — instant feedback with the redirect command in the same error
+# message.
+#
+# Installed via `core.hooksPath` set by molecule_runtime.precommit_hook
+# at workspace startup.
+
+set -e
+
+# Skip silently when GIT_AUTHOR_EMAIL/USER is unset — likely a non-agent
+# context (operator manually running git inside the container for debug).
+# Agents always have the provisioner-set GIT_AUTHOR_NAME.
+if [ -z "${GIT_AUTHOR_NAME:-}${GIT_COMMITTER_NAME:-}" ]; then
+    exit 0
+fi
+
+# Determine if we're in a public Molecule-AI repo. `git remote get-url`
+# returns nothing in repos without a remote (fine — exit clean).
+REMOTE=$(git remote get-url origin 2>/dev/null || echo "")
+
+case "$REMOTE" in
+    *Molecule-AI/molecule-monorepo*|*Molecule-AI/molecule-core*)
+        # Continue — this is a public repo we enforce on.
+        ;;
+    *)
+        # Non-target repo (internal, plugins, templates, third-party) — let it through.
+        exit 0
+        ;;
+esac
+
+# Files added or modified in this commit. --diff-filter=AM excludes
+# deletions so cleanup commits don't trip the gate.
+STAGED=$(git diff --cached --name-only --diff-filter=AM)
+[ -z "$STAGED" ] && exit 0
+
+FORBIDDEN_PATTERNS=(
+    "^research/"
+    "^marketing/"
+    "^docs/marketing/"
+    "^comment-[0-9]+\.json$"
+    "^test-pmm.*\.(txt|md)$"
+    "^tick-reflections.*\.(txt|md)$"
+    ".*-temp\.(md|txt)$"
+)
+
+OFFENDING=""
+for path in $STAGED; do
+    for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+        if echo "$path" | grep -qE "$pattern"; then
+            OFFENDING="${OFFENDING}  - ${path}  (matched: ${pattern})\n"
+            break
+        fi
+    done
+done
+
+[ -z "$OFFENDING" ] && exit 0
+
+# Refuse the commit with the redirect instructions in the same message.
+{
+    echo
+    echo "Refusing commit: internal-flavored paths cannot live in the public monorepo."
+    echo
+    echo "Offending files:"
+    printf "$OFFENDING"
+    echo
+    echo "These belong in Molecule-AI/internal. Redirect:"
+    echo
+    echo "  mkdir -p ~/repos"
+    echo "  test -d ~/repos/internal || gh repo clone Molecule-AI/internal ~/repos/internal"
+    echo "  cd ~/repos/internal"
+    echo "  git pull origin main"
+    echo "  git checkout -b <my-role>/<topic>-<date>"
+    echo "  mkdir -p <area>            # research, marketing, runbooks, etc."
+    echo "  # move your file from the monorepo into <area>/<slug>.md"
+    echo "  git add <area>/<slug>.md"
+    echo "  git commit -m '<area>: add <slug>'"
+    echo "  git push -u origin HEAD"
+    echo "  gh pr create --base main --fill"
+    echo
+    echo "If your file is genuinely public-facing (final blog post, public"
+    echo "tutorial, customer-shippable doc), use one of these monorepo paths"
+    echo "instead — these are not blocked:"
+    echo "  - docs/blog/<slug>.md"
+    echo "  - docs/tutorials/<slug>.md"
+    echo "  - docs/devrel/<slug>.md"
+    echo "  - docs/api/<slug>.md"
+    echo
+    echo "If you legitimately need a new top-level path that matches a"
+    echo "forbidden pattern, edit:"
+    echo "  .github/workflows/block-internal-paths.yml"
+    echo "with reviewer signoff and a public-facing justification — do NOT"
+    echo "work around the gate by renaming."
+    echo
+    echo "Hook source: molecule_runtime/scripts/pre-commit-block-internal-paths.sh"
+} >&2
+
+exit 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "molecule-ai-workspace-runtime"
 
-version = "0.1.10"
+version = "0.1.11"
 
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Anti-leak proposal item A. Companion to D ([role prompts decision tree](https://github.com/Molecule-AI/molecule-ai-org-template-molecule-dev/pull/48), separate PR).

## Why a local hook

Three layers already exist (.gitignore, CI gate, SHARED_RULES) and PR #1889 still leaked 2 marketing/devrel files today. CI catches it but that's 5 cycles late; agents have already opened a wrong-shaped PR.

A local pre-commit hook converts the failure from "PR opens then fails" → "commit refused immediately, with the recovery command printed in the same error message the agent reads." Agents act on what's in the current response context.

## What it does

- Hook script (`molecule_runtime/scripts/pre-commit-block-internal-paths.sh`) checks `git remote get-url origin`. Only enforces in `Molecule-AI/molecule-monorepo` + `molecule-core`. No-op everywhere else (internal, plugins, templates, third-party).
- When forbidden paths are staged, refuses + prints redirect recipe + alternative public paths + workflow-edit instructions.
- Installer (`molecule_runtime/precommit_hook.py`) extracts hook to `~/.molecule-runtime/git-hooks/`, sets `core.hooksPath` UNLESS already set (no clobber).
- Hooked into `main.py` step 0.2, right after credential helper.

Bumped to **0.1.11**.

## Acceptance

After this releases + workspaces update:

