### PR TITLE
fix: mount JSON-RPC at root — fixes silent fleet productivity loss

### DIFF
--- a/molecule_runtime/main.py
+++ b/molecule_runtime/main.py
@@ -217,10 +217,17 @@ async def main():  # pragma: no cover
         agent_card=agent_card,
     )
 
-    # Build Starlette app from route factory functions (a2a-sdk 1.x API)
+    # Build Starlette app from route factory functions (a2a-sdk 1.x API).
+    # JSON-RPC mounts at root because the platform's ProxyA2A (the only
+    # caller in this deployment) POSTs to `http://ws-<id>:8000/` — no
+    # path suffix. See workspace-server/internal/provisioner.InternalURL
+    # which returns the Docker-DNS form without a path. Mounting
+    # anywhere else produces 404 on every inbound A2A and silent fleet-
+    # wide productivity loss (baseline restart 2026-04-24: 0 delegations
+    # for 2 cycles until this was traced to `/api/v1/jsonrpc/`).
     routes = []
     routes.extend(create_agent_card_routes(agent_card))
-    routes.extend(create_jsonrpc_routes(handler, "/api/v1/jsonrpc/"))
+    routes.extend(create_jsonrpc_routes(handler, "/"))
     app = Starlette(routes=routes)
 
     # 8. Register with platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "molecule-ai-workspace-runtime"
 
-version = "0.1.11"
+version = "0.1.12"
 
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

P0 hotfix. After 0.1.11 deploy + fleet restart, every workspace healthy but **0 delegations** for 2 cycles.

Cause: a2a-sdk 1.x migration mounted JSON-RPC at `/api/v1/jsonrpc/` while platform's ProxyA2A POSTs to root `/`. 404 silent, no error logs above INFO.

Fix: `create_jsonrpc_routes(handler, "/")` — matches platform + agent-card self-advertisement. Bumped to 0.1.12.