### PR TITLE
fix: enable v0_3 compat in JSON-RPC dispatcher

### DIFF
--- a/molecule_runtime/main.py
+++ b/molecule_runtime/main.py
@@ -225,9 +225,14 @@ async def main():  # pragma: no cover
     # anywhere else produces 404 on every inbound A2A and silent fleet-
     # wide productivity loss (baseline restart 2026-04-24: 0 delegations
     # for 2 cycles until this was traced to `/api/v1/jsonrpc/`).
+    # enable_v0_3_compat=True because the platform sends v0.3-shaped
+    # JSON-RPC requests (`message/send`, `tasks/get`, etc.) that the
+    # 1.x dispatcher rejects as "Method not found" without the compat
+    # shim. The v0.3 adapter recognizes those names and routes them to
+    # the handler's on_message_send / on_get_task / etc.
     routes = []
     routes.extend(create_agent_card_routes(agent_card))
-    routes.extend(create_jsonrpc_routes(handler, "/"))
+    routes.extend(create_jsonrpc_routes(handler, "/", enable_v0_3_compat=True))
     app = Starlette(routes=routes)
 
     # 8. Register with platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "molecule-ai-workspace-runtime"
 
-version = "0.1.12"
+version = "0.1.13"
 
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"


### PR DESCRIPTION
Method-not-found fix on top of routing fix #46. See commit body.