### PR TITLE
fix(a2a): include exception class + error code in [A2A_ERROR] (#51)

### DIFF
--- a/molecule_runtime/a2a_client.py
+++ b/molecule_runtime/a2a_client.py
@@ -76,10 +76,20 @@ async def send_a2a_message(target_url: str, message: str) -> str:
                     return f"{_A2A_ERROR_PREFIX}{text}"
                 return text
             elif "error" in data:
-                return f"{_A2A_ERROR_PREFIX}{data['error'].get('message', 'unknown')}"
+                err = data["error"]
+                msg = err.get("message") or "unknown"
+                code = err.get("code")
+                if code is not None:
+                    return f"{_A2A_ERROR_PREFIX}[code={code}] {msg}"
+                return f"{_A2A_ERROR_PREFIX}{msg}"
             return str(data)
         except Exception as e:
-            return f"{_A2A_ERROR_PREFIX}{e}"
+            # #51: str(e) is empty for bare TimeoutError(), BrokenPipeError(),
+            # and several httpx transport errors — leaving "[A2A_ERROR] " with
+            # no diagnostic. Fall back to the exception class name so logs
+            # always carry at least one actionable breadcrumb.
+            detail = str(e) or type(e).__name__
+            return f"{_A2A_ERROR_PREFIX}{detail}"
 
 
 async def get_peers() -> list[dict]:

--- a/tests/test_a2a_error_observability.py
+++ b/tests/test_a2a_error_observability.py
@@ -1,0 +1,78 @@
+"""Regression tests for issue #51.
+
+The `[A2A_ERROR]` prefix from ``send_a2a_message`` must always carry a
+diagnostic suffix. Before #51 an exception whose ``str(e)`` was empty
+(bare ``TimeoutError()``, ``BrokenPipeError()``, several httpx transport
+errors) produced ``"[A2A_ERROR] "`` with a trailing space and zero
+context, masking the real cause of peer-delegation failures.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Set WORKSPACE_ID before importing molecule_runtime modules — platform_auth
+# evaluates it at import time and refuses to load otherwise.
+os.environ.setdefault("WORKSPACE_ID", "test-workspace")
+
+from molecule_runtime.a2a_client import _A2A_ERROR_PREFIX  # noqa: E402
+from molecule_runtime import a2a_client  # noqa: E402
+
+
+class _BareException(Exception):
+    """Exception whose str() is empty — mimics bare TimeoutError()."""
+
+    def __str__(self) -> str:  # noqa: D401
+        return ""
+
+
+class _StubAsyncClient:
+    """Async context manager that raises a supplied exception on .post()."""
+
+    def __init__(self, exc: BaseException) -> None:
+        self._exc = exc
+
+    async def __aenter__(self) -> "_StubAsyncClient":
+        return self
+
+    async def __aexit__(self, *_exc) -> bool:
+        return False
+
+    async def post(self, *_args, **_kwargs):
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_bare_exception_yields_class_name(monkeypatch):
+    """When str(e) is empty the result must still include the exception class."""
+
+    def _factory(*_a, **_kw):
+        return _StubAsyncClient(_BareException())
+
+    monkeypatch.setattr(a2a_client.httpx, "AsyncClient", _factory)
+    monkeypatch.setattr(a2a_client, "PLATFORM_URL", "http://stub")
+    monkeypatch.setattr(a2a_client, "auth_headers", lambda: {})
+
+    result = await a2a_client.send_a2a_message("peer-ws-id", "hi")
+    assert result.startswith(_A2A_ERROR_PREFIX)
+    suffix = result[len(_A2A_ERROR_PREFIX):]
+    assert suffix.strip() != "", f"expected non-empty suffix, got {result!r}"
+    assert "BareException" in suffix
+
+
+@pytest.mark.asyncio
+async def test_exception_with_message_passes_through(monkeypatch):
+    """Regular exception messages are preserved."""
+
+    def _factory(*_a, **_kw):
+        return _StubAsyncClient(RuntimeError("upstream 429"))
+
+    monkeypatch.setattr(a2a_client.httpx, "AsyncClient", _factory)
+    monkeypatch.setattr(a2a_client, "PLATFORM_URL", "http://stub")
+    monkeypatch.setattr(a2a_client, "auth_headers", lambda: {})
+
+    result = await a2a_client.send_a2a_message("peer-ws-id", "hi")
+    assert result == f"{_A2A_ERROR_PREFIX}upstream 429"

--- a/tests/test_a2a_error_observability.py
+++ b/tests/test_a2a_error_observability.py
@@ -5,21 +5,31 @@ diagnostic suffix. Before #51 an exception whose ``str(e)`` was empty
 (bare ``TimeoutError()``, ``BrokenPipeError()``, several httpx transport
 errors) produced ``"[A2A_ERROR] "`` with a trailing space and zero
 context, masking the real cause of peer-delegation failures.
+
+CI does not install pytest-asyncio — use the local _run helper pattern
+established in test_shared_runtime.py.
 """
 
 from __future__ import annotations
 
+import asyncio
 import os
-import sys
-
-import pytest
 
 # Set WORKSPACE_ID before importing molecule_runtime modules — platform_auth
 # evaluates it at import time and refuses to load otherwise.
 os.environ.setdefault("WORKSPACE_ID", "test-workspace")
 
-from molecule_runtime.a2a_client import _A2A_ERROR_PREFIX  # noqa: E402
 from molecule_runtime import a2a_client  # noqa: E402
+from molecule_runtime.a2a_client import _A2A_ERROR_PREFIX  # noqa: E402
+
+
+def _run(coro):
+    """Run an async coroutine synchronously (no pytest-asyncio available)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 class _BareException(Exception):
@@ -45,8 +55,7 @@ class _StubAsyncClient:
         raise self._exc
 
 
-@pytest.mark.asyncio
-async def test_bare_exception_yields_class_name(monkeypatch):
+def test_bare_exception_yields_class_name(monkeypatch):
     """When str(e) is empty the result must still include the exception class."""
 
     def _factory(*_a, **_kw):
@@ -56,15 +65,14 @@ async def test_bare_exception_yields_class_name(monkeypatch):
     monkeypatch.setattr(a2a_client, "PLATFORM_URL", "http://stub")
     monkeypatch.setattr(a2a_client, "auth_headers", lambda: {})
 
-    result = await a2a_client.send_a2a_message("peer-ws-id", "hi")
+    result = _run(a2a_client.send_a2a_message("peer-ws-id", "hi"))
     assert result.startswith(_A2A_ERROR_PREFIX)
     suffix = result[len(_A2A_ERROR_PREFIX):]
     assert suffix.strip() != "", f"expected non-empty suffix, got {result!r}"
     assert "BareException" in suffix
 
 
-@pytest.mark.asyncio
-async def test_exception_with_message_passes_through(monkeypatch):
+def test_exception_with_message_passes_through(monkeypatch):
     """Regular exception messages are preserved."""
 
     def _factory(*_a, **_kw):
@@ -74,5 +82,5 @@ async def test_exception_with_message_passes_through(monkeypatch):
     monkeypatch.setattr(a2a_client, "PLATFORM_URL", "http://stub")
     monkeypatch.setattr(a2a_client, "auth_headers", lambda: {})
 
-    result = await a2a_client.send_a2a_message("peer-ws-id", "hi")
+    result = _run(a2a_client.send_a2a_message("peer-ws-id", "hi"))
     assert result == f"{_A2A_ERROR_PREFIX}upstream 429"


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Closes #51.

## Problem

`send_a2a_message` catches broad exceptions and returns `f\"[A2A_ERROR] {e}\"`. When the exception has no args (bare `TimeoutError()`, `BrokenPipeError()`, some httpx transport errors), `str(e)` evaluates to `\"\"` — producing \`\"[A2A_ERROR] \"\` with a trailing space and **zero diagnostic content**.

Observed in production: 22+ such entries in 75 min across 7 leads during the MiniMax M2.7 trial rate-limit episode (2026-04-24 18:00+). With no breadcrumb in `activity_logs.response_body`, root-causing peer-delegation failures required pulling container logs workspace-by-workspace.

## Fix

`molecule_runtime/a2a_client.py`:

```python
except Exception as e:
    detail = str(e) or type(e).__name__
    return f\"{_A2A_ERROR_PREFIX}{detail}\"
```

Plus: the error-branch now includes `error.code` when present:

```python
elif \"error\" in data:
    err = data[\"error\"]
    msg = err.get(\"message\") or \"unknown\"
    code = err.get(\"code\")
    if code is not None:
        return f\"{_A2A_ERROR_PREFIX}[code={code}] {msg}\"
    return f\"{_A2A_ERROR_PREFIX}{msg}\"
```

## Tests

`tests/test_a2a_error_observability.py`:
- `test_bare_exception_yields_class_name` — passes when suffix contains the exception class (e.g. `BareException`)
- `test_exception_with_message_passes_through` — passes when a regular `RuntimeError(\"upstream 429\")` is preserved unchanged

Full suite: 119 passed, 0 failed.

## Test plan
- [ ] CI green
- [ ] After promote + workspace-template rebuild, `SELECT COUNT(*) FROM activity_logs WHERE response_body::text LIKE '%A2A_ERROR] %' AND response_body::text NOT LIKE '%A2A_ERROR] _%'` drops to 0 over next 24 h

## Related

Root cause of the A2A_ERROR flood is the MiniMax trial hitting its usage limit (429 \`usage limit exceeded (2056)\`). That is a CEO-level provider-choice decision — surfacing in this cycle's maintenance report.