### PR TITLE
chore: bump to 0.1.15 — ship A2A_ERROR observability fix (#51)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "molecule-ai-workspace-runtime"
 
-version = "0.1.14"
+version = "0.1.15"
 
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

PR #52 merged the a2a_client observability fix but didn't bump the version. Without a bump, the publish-on-tag workflow has nothing to release and workspace-template rebuilds keep pulling 0.1.14. Fix on main != fix in running agents.

Bumping to 0.1.15. After staging→main promote, someone with tag-push perms does:
`git tag v0.1.15 && git push origin v0.1.15`

publish.yml fires, PyPI gets the new wheel, workspace-template image rebuild pulls it in on next trigger, and the A2A_ERROR observability fix finally reaches agents.

## Test plan
- [ ] CI green
- [ ] After merge + tag, verify https://pypi.org/project/molecule-ai-workspace-runtime/0.1.15/ is live
- [ ] After workspace-template-claude-code image rebuild, check `docker exec ws-X pip show molecule-ai-workspace-runtime` returns 0.1.15
- [ ] A2A_ERROR count with empty suffix drops to 0 over next 24h