### PR TITLE
chore(ci): enroll in org-wide secret-scan reusable workflow (#2109 rollout)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,6 +1,6 @@
 name: Secret scan
 
-# Calls the canonical reusable workflow in molecule-monorepo. Defense
+# Calls the canonical reusable workflow in molecule-core. Defense
 # against the #2090-class leak (a hosted-agent commit slipping a
 # credential-shaped string into a PR). One source of truth for the
 # pattern set; this file just enrolls the repo.
@@ -9,8 +9,12 @@ name: Secret scan
 # so a leaked credential in a release tag would propagate to every
 # downstream tenant on next pip install.
 #
+# Pinned to @staging because that's the active default branch on the
+# upstream repo (main lags behind via the staging-promotion workflow).
+# Updates ride along automatically as the upstream regex set evolves.
+#
 # To update the regex set, edit
-# Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml.
+# Molecule-AI/molecule-core/.github/workflows/secret-scan.yml.
 
 on:
   pull_request:
@@ -22,4 +26,4 @@ on:
 
 jobs:
   secret-scan:
-    uses: Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml@main
+    uses: Molecule-AI/molecule-core/.github/workflows/secret-scan.yml@staging

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,25 @@
+name: Secret scan
+
+# Calls the canonical reusable workflow in molecule-monorepo. Defense
+# against the #2090-class leak (a hosted-agent commit slipping a
+# credential-shaped string into a PR). One source of truth for the
+# pattern set; this file just enrolls the repo.
+#
+# Higher stakes here than most repos: this package publishes to PyPI,
+# so a leaked credential in a release tag would propagate to every
+# downstream tenant on next pip install.
+#
+# To update the regex set, edit
+# Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, staging]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  secret-scan:
+    uses: Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

3-line enrollment in the canonical secret-scan workflow shipped in Molecule-AI/molecule-monorepo#2109. Defense against the #2090-class leak (a hosted-agent commit slipping a credential-shaped string into a PR — caught at the PR layer, before merge).

Higher stakes here than most repos: this package publishes to PyPI, so a leaked credential on a release tag would propagate to every downstream tenant on next pip install.

Pairs with the runtime-side pre-commit hook (`scripts/pre-commit-checks.sh`) which catches local commits before they reach a PR.

## Test plan
- [ ] CI green — the workflow self-runs on this PR; if cross-org workflow_call works as expected, the `secret-scan` job appears in the checks list and passes
- [ ] Post-merge: confirm the secret-scan job runs on the next PR opened against this repo