### PR TITLE
chore(precommit): add sk-cp- MiniMax pattern (F1088 retroactive fix); bump 0.1.16 → 0.1.17

### DIFF
--- a/molecule_runtime/scripts/pre-commit-checks.sh
+++ b/molecule_runtime/scripts/pre-commit-checks.sh
@@ -66,6 +66,7 @@ SECRET_PATTERNS=(
     'sk-ant-[A-Za-z0-9_-]{40,}'      # Anthropic API key
     'sk-proj-[A-Za-z0-9_-]{40,}'     # OpenAI project key
     'sk-svcacct-[A-Za-z0-9_-]{40,}'  # OpenAI service-account key
+    'sk-cp-[A-Za-z0-9_-]{60,}'       # MiniMax API key (F1088 vector — caught only after the fact)
     'xox[baprs]-[A-Za-z0-9-]{20,}'   # Slack tokens (bot/app/user/refresh)
     'AKIA[0-9A-Z]{16}'               # AWS access key ID
     'ASIA[0-9A-Z]{16}'               # AWS STS temp access key ID

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "molecule-ai-workspace-runtime"
 
-version = "0.1.16"
+version = "0.1.17"
 
 description = "Molecule AI workspace runtime — shared infrastructure for all agent adapters"
 requires-python = ">=3.11"

--- a/tests/test_precommit_hook.py
+++ b/tests/test_precommit_hook.py
@@ -139,3 +139,25 @@ def test_secret_scan_runs_on_third_party_repos(repo: Path) -> None:
     )
     assert result.returncode != 0, "secret scan must fire even without a Molecule-AI remote"
     assert "sk-ant-" in result.stderr
+
+
+@pytest.mark.skipif(_BASH is None, reason="bash not on PATH")
+def test_secret_scan_catches_minimax_sk_cp_token(repo: Path) -> None:
+    """Lock for the F1088 incident — a MiniMax sk-cp-* token leaked in
+    plaintext, undetected by the original pattern set because sk-cp- was
+    never in it. Pattern added retroactively; this test guards against
+    accidental removal."""
+    leaky = repo / "config.yml"
+    # Fake-but-pattern-matching token: 65 chars after the sk-cp- prefix.
+    leaky.write_text(
+        "minimax_key: sk-cp-FAKE_DO_NOT_USE_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+    )
+    _run(["git", "add", "config.yml"], cwd=repo).check_returncode()
+
+    result = _run(
+        ["git", "commit", "-m", "config: minimax", "--no-gpg-sign"],
+        cwd=repo,
+        env={"GIT_AUTHOR_NAME": "test-agent", "GIT_COMMITTER_NAME": "test-agent"},
+    )
+    assert result.returncode != 0, "secret scan must catch sk-cp- MiniMax tokens"
+    assert "sk-cp-" in result.stderr


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

F1088 leaked a MiniMax sk-cp-* token in plaintext, undetected by the runtime's pre-commit hook because sk-cp- was never in its pattern list. This PR closes that gap.

- Adds `sk-cp-[A-Za-z0-9_-]{60,}` to `molecule_runtime/scripts/pre-commit-checks.sh`  (mirrored to the canonical CI workflow in Molecule-AI/molecule-core PR for the same change).
- Adds `test_secret_scan_catches_minimax_sk_cp_token` in `tests/test_precommit_hook.py` — locks the contract so accidental removal of the pattern fails CI.
- Bumps version 0.1.16 → 0.1.17.

Min-length 60 chars after prefix is conservative against false positives.

Keep aligned with the canonical workflow's pattern set (see the docstring in `pre-commit-checks.sh` lines 14-19).