### PR TITLE
fix(pre-commit): align SECRET_PATTERNS with molecule-core canonical (add sk-cp-)

### DIFF
--- a/molecule_runtime/scripts/pre-commit-checks.sh
+++ b/molecule_runtime/scripts/pre-commit-checks.sh
@@ -66,6 +66,7 @@ SECRET_PATTERNS=(
     'sk-ant-[A-Za-z0-9_-]{40,}'      # Anthropic API key
     'sk-proj-[A-Za-z0-9_-]{40,}'     # OpenAI project key
     'sk-svcacct-[A-Za-z0-9_-]{40,}'  # OpenAI service-account key
+    'sk-cp-[A-Za-z0-9_-]{60,}'       # MiniMax API key (F1088 vector — caught only after the fact)
     'xox[baprs]-[A-Za-z0-9-]{20,}'   # Slack tokens (bot/app/user/refresh)
     'AKIA[0-9A-Z]{16}'               # AWS access key ID
     'ASIA[0-9A-Z]{16}'               # AWS STS temp access key ID


### PR DESCRIPTION
## Summary

Adds the missing \`sk-cp-\` (MiniMax F1088 vector) pattern to the runtime-side pre-commit hook so it's byte-aligned with [molecule-core's canonical SECRET_PATTERNS](https://github.com/Molecule-AI/molecule-core/blob/staging/.github/workflows/secret-scan.yml).

## Why

Canonical ships 13 patterns; this hook had 12. The missing one is \`sk-cp-[A-Za-z0-9_-]{60,}\` (MiniMax). Result: a local commit could pass the bundled pre-commit but get rejected by the org-wide CI scan — useless friction.

## Refs

- Task #139 — the upcoming molecule-core CI lint that will detect drift like this automatically. Clearing this drift so the lint passes from day 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)